### PR TITLE
FIX: saveAttrNames cannot be used anymore

### DIFF
--- a/assets/javascripts/discourse/initializers/mail-daily-summary.js.es6
+++ b/assets/javascripts/discourse/initializers/mail-daily-summary.js.es6
@@ -1,10 +1,23 @@
 import { observes } from "discourse-common/utils/decorators";
 import EmailPreferencesController from 'discourse/controllers/preferences/emails';
 import UserController from 'discourse/controllers/user';
+import { withPluginApi } from "discourse/lib/plugin-api";
 
 export default {
   name: 'mail_daily_summary',
   initialize(container){
+    withPluginApi("1.2.0", (api) => {
+      api.registerValueTransformer(
+        "preferences-save-attributes",
+        ({ value: attrs, context }) => {
+          if (context.page === "emails") {
+            attrs.push("custom_fields");
+          }
+          return attrs;
+        }
+      );
+    });
+
     EmailPreferencesController.reopen({
       userMLMDailySummaryEnabled(){
         const user = this.get("model");
@@ -15,7 +28,6 @@ export default {
       _setUserMLMDailySummary(){
         var attrNames = this.get("saveAttrNames");
         attrNames.push('custom_fields');
-        this.set("saveAttrNames", attrNames);
         const user = this.get("model");
         var userMLMDailySummaryEnabled = user.custom_fields.user_mlm_daily_summary_enabled;
         if (userMLMDailySummaryEnabled === undefined) {

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-mail-daily-summary
 # about: Send a daily summary email.
-# version: 0.12
+# version: 0.13
 # authors: Thomas Kalka
 # url: https://www.github.com/thoka/discourse-mail-daily-summary
 # meta_topic_id: 306214


### PR DESCRIPTION
Use a value transformer to add the custom fields to the attributes that need to be saved

See core commit https://github.com/discourse/discourse/commit/ee1a1c7219fea70215300c9bf81ce215a09ce17b
