### PR TITLE
More enhancements!

### DIFF
--- a/app/helpers/mail_daily_summary_helper.rb
+++ b/app/helpers/mail_daily_summary_helper.rb
@@ -34,10 +34,16 @@ module MailDailySummaryHelper
     @daily_summary_excerpt_data[post.id] ||=
       begin
         minimum_length = SiteSetting.mail_daily_summary_min_excerpt_length.to_i
+        maximum_length = SiteSetting.mail_daily_summary_max_excerpt_length.to_i
         source_html = post.cooked.to_s
 
         if minimum_length <= 0
-          { html: source_html, truncated: false }
+          if maximum_length > 0
+            excerpt_html = daily_summary_plain_text_excerpt_from(source_html, maximum_length)
+            { html: excerpt_html, truncated: excerpt_html != source_html }
+          else
+            { html: source_html, truncated: false }
+          end
         else
           selected_html =
             daily_summary_first_paragraphs_from(
@@ -46,6 +52,10 @@ module MailDailySummaryHelper
             ).to_s
 
           excerpt_html = selected_html.presence || source_html
+
+          if maximum_length > 0 && daily_summary_text_length_for(excerpt_html) > maximum_length
+            excerpt_html = daily_summary_plain_text_excerpt_from(source_html, maximum_length)
+          end
 
           { html: excerpt_html, truncated: excerpt_html != source_html }
         end
@@ -71,5 +81,34 @@ module MailDailySummaryHelper
     return result if result.present?
 
     doc.css("body > p:not(:empty), body > div:not(:empty), body > p > div.lightbox-wrapper img").first
+  end
+
+  def daily_summary_plain_text_excerpt_from(html, maximum_length)
+    text = daily_summary_plain_text_from(html)
+
+    return text if maximum_length <= 0 || text.length < maximum_length
+    return "" if maximum_length <= 1
+    return "..."[0, maximum_length - 1] if maximum_length <= 4
+
+    cutoff = text[0, maximum_length - 4]
+    boundary = cutoff.rindex(/\s/)
+
+    base_excerpt =
+      if boundary && boundary.positive?
+        cutoff[0...boundary].rstrip
+      else
+        cutoff.rstrip
+      end
+
+    base_excerpt = cutoff.rstrip if base_excerpt.blank?
+    "#{base_excerpt}..."
+  end
+
+  def daily_summary_text_length_for(html)
+    daily_summary_plain_text_from(html).length
+  end
+
+  def daily_summary_plain_text_from(html)
+    Nokogiri.HTML5(html.to_s).text.gsub(/\s+/, " ").strip
   end
 end

--- a/app/helpers/mail_daily_summary_helper.rb
+++ b/app/helpers/mail_daily_summary_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module MailDailySummaryHelper
+  ELLIPSIS = "…"
+
   def daily_summary_topic(topic, count)
     render(partial: "daily_summary_topic", locals: { topic: topic })
   end
@@ -88,9 +90,9 @@ module MailDailySummaryHelper
 
     return text if maximum_length <= 0 || text.length < maximum_length
     return "" if maximum_length <= 1
-    return "..."[0, maximum_length - 1] if maximum_length <= 4
+    return ELLIPSIS if maximum_length == 2
 
-    cutoff = text[0, maximum_length - 4]
+    cutoff = text[0, maximum_length - 2]
     boundary = cutoff.rindex(/\s/)
 
     base_excerpt =
@@ -101,7 +103,7 @@ module MailDailySummaryHelper
       end
 
     base_excerpt = cutoff.rstrip if base_excerpt.blank?
-    "#{base_excerpt}..."
+    "#{base_excerpt}#{ELLIPSIS}"
   end
 
   def daily_summary_text_length_for(html)

--- a/app/jobs/regular/user_daily_summary_email.rb
+++ b/app/jobs/regular/user_daily_summary_email.rb
@@ -2,6 +2,32 @@
 
 module Jobs
   class UserDailySummaryEmail < ::Jobs::UserEmail
+    def execute(args)
+      frequency = args[:frequency] || "daily"
+      user_id = args[:user_id]
+
+      # Calculate the "since" window based on frequency
+      since = case frequency
+              when "weekly"
+                7.days.ago
+              else # "daily"
+                1.day.ago
+              end
+
+      # Update the args with the calculated since value
+      args[:since] = since.to_s
+
+      # Call parent's execute which handles the email sending
+      super(args)
+
+      # After successful send, update the user's last_sent_at timestamp
+      user = User.find_by(id: user_id)
+      if user
+        user.custom_fields["user_mail_summary_last_sent_at"] = Time.now.to_s
+        user.save_custom_fields(true)
+      end
+    end
+
     def message_for_email(user, post, type, notification, args = nil)
       args ||= {}
 
@@ -37,6 +63,7 @@ module Jobs
       end
 
       email_args[:since] = args[:since]
+      email_args[:frequency] = args[:frequency] if args[:frequency].present?
 
       message =
         EmailLog.unique_email_per_post(post, user) do

--- a/app/jobs/scheduled/enqueue_mail_daily_summary.rb
+++ b/app/jobs/scheduled/enqueue_mail_daily_summary.rb
@@ -10,13 +10,27 @@ module Jobs
       Rails.logger.warn("eMDS: #{msg}")
     end
 
-    def today_at(time)
+    def today_at(time, current_time = Time.zone.now)
       hour, minute = time.split(":").map(&:to_i)
-      Time.new.change(hour: hour, min: minute, usec: 0)
+      current_time.change(hour: hour, min: minute, sec: 0, usec: 0)
+    end
+
+    def scheduled_time_reached?(current_time)
+      scheduled_time = SiteSetting.mail_daily_summary_at
+      return true if scheduled_time.blank?
+
+      current_time >= today_at(scheduled_time, current_time)
     end
 
     def execute(args)
       return unless SiteSetting.mail_daily_summary_enabled
+
+      current_time = Time.zone.now
+
+      unless scheduled_time_reached?(current_time)
+        debug("waiting for scheduled time")
+        return
+      end
 
       debug("Starting enqueue cycle")
 
@@ -29,13 +43,15 @@ module Jobs
       end
 
       # Process weekly users (only on the correct day)
-      if Time.now.wday == SiteSetting.mail_daily_summary_day_of_week
+      if current_time.wday == SiteSetting.mail_daily_summary_day_of_week
         weekly_users = target_weekly_users
         debug("Weekly users to process: #{weekly_users.count}")
         weekly_users.each do |user_id|
           opts = { type: "daily_summary", user_id: user_id, frequency: "weekly" }
           Jobs.enqueue(:user_daily_summary_email, opts)
         end
+      else
+        debug("waiting for the right day of week")
       end
     end
 

--- a/app/jobs/scheduled/enqueue_mail_daily_summary.rb
+++ b/app/jobs/scheduled/enqueue_mail_daily_summary.rb
@@ -18,84 +18,28 @@ module Jobs
     def execute(args)
       return unless SiteSetting.mail_daily_summary_enabled
 
-      scheduled_time = SiteSetting.mail_daily_summary_at
+      debug("Starting enqueue cycle")
 
-      last_run_at =
-        begin
-          Time.parse(SiteSetting.mail_daily_summary_last_run_at)
-        rescue StandardError
-          nil
-        end
-
-      current_time = Time.now
-      time_to_look_back = SiteSetting.mail_daily_summary_frequency == "weekly" ? 7.days : 1.day
-
-      if scheduled_time.length > 0
-        if scheduled_time.length == 0
-          scheduled_time = today_at("00:00")
-        else
-          scheduled_time = today_at(scheduled_time)
-        end
-
-        if SiteSetting.mail_daily_summary_frequency == "weekly"
-          (0..6).each do
-            if scheduled_time.wday != SiteSetting.mail_daily_summary_day_of_week
-              scheduled_time += 1.day
-            end
-          end
-        end
-
-        debug "last_run_at: #{last_run_at}, current_time: #{current_time}, scheduled_at: #{scheduled_time}"
-
-        if current_time < scheduled_time
-          debug("waiting for scheduled time")
-          return
-        end
-
-        if last_run_at
-          last_day_run = last_run_at.change(hour: 0, min: 0, sec: 0, usec: 0)
-          current_day = current_time.change(hour: 0, min: 0, sec: 0, usec: 0)
-
-          if current_day <= last_day_run
-            debug("allready run today")
-            return
-          end
-          max_ago = Rails.env.production? ? 31.day : 1000.day
-          since = [last_run_at, scheduled_time - max_ago].max
-        else
-          since = scheduled_time - time_to_look_back
-        end
-
-        compare_user_first_seen_hour = false
-      else
-        if SiteSetting.mail_daily_summary_frequency == "weekly"
-          if current_time.wday != SiteSetting.mail_daily_summary_day_of_week
-            debug("waiting for the right day of week")
-            return
-          end
-        end
-
-        compare_user_first_seen_hour = true
-        if last_run_at && last_run_at.hour == current_time.hour
-          debug("allready run this hour")
-          return
-        end
-
-        since = current_time.change(min: 0, sec: 0, usec: 0) - time_to_look_back
+      # Process daily users
+      daily_users = target_daily_users
+      debug("Daily users to process: #{daily_users.count}")
+      daily_users.each do |user_id|
+        opts = { type: "daily_summary", user_id: user_id, frequency: "daily" }
+        Jobs.enqueue(:user_daily_summary_email, opts)
       end
 
-      SiteSetting.mail_daily_summary_last_run_at = current_time.to_s
-
-      t = target_user_ids(compare_user_first_seen_hour)
-      debug("since: #{since} target_users: #{t}")
-
-      t.each do |user_id|
-        opts = { type: "daily_summary", user_id: user_id, since: since.to_s }
-        Jobs.enqueue(:user_daily_summary_email, opts)
+      # Process weekly users (only on the correct day)
+      if Time.now.wday == SiteSetting.mail_daily_summary_day_of_week
+        weekly_users = target_weekly_users
+        debug("Weekly users to process: #{weekly_users.count}")
+        weekly_users.each do |user_id|
+          opts = { type: "daily_summary", user_id: user_id, frequency: "weekly" }
+          Jobs.enqueue(:user_daily_summary_email, opts)
+        end
       end
     end
 
-    def target_user_ids(compare_hour = true)
+    def base_user_scope
       users =
         User
           .real
@@ -109,7 +53,7 @@ module Jobs
             "COALESCE(first_seen_at, '2010-01-01') <= CURRENT_TIMESTAMP - '23 HOURS'::INTERVAL",
           ) # don't send unless you've been around for a day already
 
-      debug("users before filter: #{users.pluck(:id)}")
+      # Apply opt-in/out filter
       if !SiteSetting.mail_daily_summary_enable_as_default
         enabled_ids =
           UserCustomField.where(name: "user_mlm_daily_summary_enabled", value: %w[true t]).pluck(
@@ -124,12 +68,67 @@ module Jobs
         users = users.where.not(id: disabled_ids)
       end
 
+      users
+    end
+
+    def target_daily_users
+      users_due_for_frequency("daily", "1 day")
+    end
+
+    def target_weekly_users
+      users_due_for_frequency("weekly", "7 days")
+    end
+
+    def users_due_for_frequency(frequency, interval)
+      users = base_user_scope
+
+      if SiteSetting.mail_daily_summary_frequency == frequency
+        opposite_frequency = frequency == "daily" ? "weekly" : "daily"
+
+        # Site default matches this frequency, so only exclude users who explicitly override to the opposite value.
+        users =
+          users.where(
+            "NOT EXISTS (
+              SELECT 1 FROM user_custom_fields frequency_cf
+              WHERE frequency_cf.user_id = users.id
+                AND frequency_cf.name = 'user_mail_summary_frequency'
+                AND frequency_cf.value = ?
+            )",
+            opposite_frequency,
+          )
+      else
+        # Site default does not match this frequency, so only include explicit overrides.
+        users =
+          users.where(
+            "EXISTS (
+              SELECT 1 FROM user_custom_fields frequency_cf
+              WHERE frequency_cf.user_id = users.id
+                AND frequency_cf.name = 'user_mail_summary_frequency'
+                AND frequency_cf.value = ?
+            )",
+            frequency,
+          )
+      end
+
       users =
         users.where(
-          "date_part('hour', first_seen_at) = date_part('hour', CURRENT_TIMESTAMP)",
-        ) if compare_hour # where the hour of first_seen_at is the same as the current hour
-      users = users.pluck(:id)
+          "NOT EXISTS (
+            SELECT 1 FROM user_custom_fields last_sent_cf
+            WHERE last_sent_cf.user_id = users.id
+              AND last_sent_cf.name = 'user_mail_summary_last_sent_at'
+              AND last_sent_cf.value::timestamp > CURRENT_TIMESTAMP - ?::INTERVAL
+          )",
+          interval,
+        )
 
+      users.pluck(:id)
+    end
+
+    def target_user_ids(compare_hour = true)
+      # Deprecated: kept for backwards compatibility if needed
+      # New logic uses target_daily_users and target_weekly_users
+      users = base_user_scope
+      users = users.pluck(:id)
       users += MailDailySummary.auto_enabled_users
       users.uniq
     end

--- a/assets/javascripts/discourse/connectors/user-preferences-emails/mail-daily-summary.gjs
+++ b/assets/javascripts/discourse/connectors/user-preferences-emails/mail-daily-summary.gjs
@@ -1,6 +1,8 @@
 import Component from "@ember/component";
 import { classNames } from "@ember-decorators/component";
+import { fn } from "@ember/helper";
 import PreferenceCheckbox from "discourse/components/preference-checkbox";
+import ComboBox from "discourse/select-kit/components/combo-box";
 import { i18n } from "discourse-i18n";
 
 @classNames("user-preferences-emails-outlet", "mail-daily-summary")
@@ -34,6 +36,34 @@ export default class MailDailySummaryConnector extends Component {
     return normalizedValue;
   }
 
+  get userMailSummaryFrequency() {
+    return (
+      this.model?.custom_fields?.user_mail_summary_frequency || "default"
+    );
+  }
+
+  set userMailSummaryFrequency(value) {
+    this.model.set("custom_fields.user_mail_summary_frequency", value);
+    return value;
+  }
+
+  get frequencyOptions() {
+    return [
+      {
+        name: i18n("mail_daily_summary.frequency_default"),
+        value: "default",
+      },
+      {
+        name: i18n("mail_daily_summary.frequency_daily"),
+        value: "daily",
+      },
+      {
+        name: i18n("mail_daily_summary.frequency_weekly"),
+        value: "weekly",
+      },
+    ];
+  }
+
   <template>
     {{#if this.siteSettings.mail_daily_summary_enabled}}
       <div class="control-group">
@@ -45,6 +75,21 @@ export default class MailDailySummaryConnector extends Component {
         <div class="instructions">{{{i18n
             "mail_daily_summary.instructions"
           }}}</div>
+
+        {{#if this.userMLMDailySummaryEnabled}}
+          <div class="control-group mail-daily-summary-frequency">
+            <ComboBox
+              @content={{this.frequencyOptions}}
+              @value={{this.userMailSummaryFrequency}}
+              @nameProperty="name"
+              @valueProperty="value"
+              @onChange={{fn (mut this.userMailSummaryFrequency)}}
+            />
+            <div class="instructions">{{{i18n
+                "mail_daily_summary.frequency_instructions"
+              }}}</div>
+          </div>
+        {{/if}}
       </div>
     {{/if}}
   </template>

--- a/assets/javascripts/discourse/initializers/mail-daily-summary.js
+++ b/assets/javascripts/discourse/initializers/mail-daily-summary.js
@@ -1,9 +1,12 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 
+const PLUGIN_ID = "discourse-mail-daily-summary";
+
 export default {
   name: "mail_daily_summary",
   initialize(container) {
     withPluginApi("1.2.0", (api) => {
+      api.setAdminPluginIcon(PLUGIN_ID, "envelope");
       api.addSaveableCustomFields("emails");
     });
   },

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1,6 +1,12 @@
 de:
   js:
     mail_daily_summary:
-      daily: "Sende mir eine tägliche Zusammenstellungen"
-      preference_label: "Aktiviere tägliche Zusammenstellungen"
-      instructions: "Wenn du dies aktivierst, bekommst du eine tägliche Zusammenstellung der Aktivitäten dieses Forums"
+      daily: "Aktivitaets-Update"
+      preference_label: "Aktiviere E-Mails fuer Aktivitaets-Updates"
+      instructions: "Du erhaeltst ein regelmaessiges Aktivitaets-Update mit allen aktuellen Forenaktivitaeten."
+      frequency_label: "Haeufigkeit"
+      frequency_default: "Standardeinstellung der Website"
+      frequency_daily: "Täglich"
+      frequency_weekly: "Wöchentlich"
+      frequency_instructions: "Waehle aus, wie oft du E-Mails mit Aktivitaets-Updates erhalten moechtest."
+

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,7 +1,11 @@
 en:
   js:
     mail_daily_summary:
-      daily: "Send daily email summaries"
-      preference_label: "Enable daily summaries"
-      instructions: "You will receive a daily summary of the day's activity."
-      
+      daily: "Activity Update"
+      preference_label: "Enable Activity Update emails"
+      instructions: "You will receive a periodical Activity Update with all recent forum activity."
+      frequency_label: "Frequency"
+      frequency_default: "Site Default"
+      frequency_daily: "Daily"
+      frequency_weekly: "Weekly"
+      frequency_instructions: "Choose how often you would like to receive Activity Update emails."

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -1,25 +1,28 @@
 de:
   site_settings:
-    mail_daily_summary_enabled: 'Erlaube Benutzern eine tägliche Zusammenstellung (Update) zu empfangen.'
-    mail_daily_summary_at: 'Wann soll der Zusammenstellung versendet werden? (HH:MM)'
+    mail_daily_summary_enabled: 'Erlaube Benutzern, regelmaessige E-Mails mit Aktivitaets-Updates zu erhalten.'
+    mail_daily_summary_at: 'Wann soll die E-Mail mit Aktivitaets-Update erstellt werden? (HH:MM)'
     mail_daily_summary_last_run_at: 'Zeitstempel des letzten Versands'
     mail_daily_summary_debug_mode: 'Debug Log aktivieren'
     mail_daily_summary_add_unsubscribe_link: 'Füge einen Link zum Abbestellen hinzu'
-    mail_daily_summary_auto_enabled_groups: 'Gruppen, die die tägliche Zusammenstellung unabhängig von eigenen Einstellungen erhalten sollen'
-    mail_daily_summary_enabled_categories: 'Falls gesetzt, werden nur Themen in diesen Kategorien (inklusive Unterkategorien), berücksichtigt'
+    mail_daily_summary_auto_enabled_groups: 'Diese Gruppen erhalten E-Mails mit Aktivitaets-Updates unabhaengig von individuellen Einstellungen'
+    mail_daily_summary_enabled_categories: 'Falls gesetzt, werden nur Themen in diesen Kategorien (inklusive Unterkategorien) in E-Mails mit Aktivitaets-Updates aufgenommen'
     mail_daily_summary_disabled_groups: 'Gruppen, die die tägliche Zusammenfassung nicht erhalten sollen (überschreibt die Einstellung oben)'
     mail_daily_summary_enable_as_default: 'Versand als Voreinstellung für alle Nutzer aktivieren'
-    mail_daily_summary_max_posts_per_topic: 'Maximale Anzahl der pro Thema angezeigten Beiträge in der täglichen Zusammenfassung (0 = kein Maximum)'
-    mail_daily_summary_min_excerpt_length: 'Auszugslänge für den Abschneidepunkt je angezeigtem Beitrag in der täglichen Zusammenfassung (0 = kein Maximum)'
-    mail_daily_summary_preview_uses_daily_summary: 'In der Admin-Vorschau die tägliche Zusammenfassung statt des Digest verwenden'
+    mail_daily_summary_frequency: 'Standardhaeufigkeit fuer E-Mails mit Aktivitaets-Updates'
+    mail_daily_summary_day_of_week: 'Wochentag, an dem die E-Mail mit Aktivitaets-Update gesendet wird (0 = Sonntag)'
+    mail_daily_summary_max_posts_per_topic: 'Maximale Anzahl der pro Thema angezeigten Beitraege in periodischen E-Mails mit Aktivitaets-Updates (0 = kein Maximum)'
+    mail_daily_summary_min_excerpt_length: 'Auszugslaenge fuer den Abschneidepunkt je angezeigtem Beitrag in periodischen E-Mails mit Aktivitaets-Updates (0 = kein Maximum)'
+    mail_daily_summary_preview_uses_daily_summary: 'In der Admin-Vorschau periodisches Aktivitaets-Update statt Digest verwenden'
   user_notifications:
     daily_summary:
       why: "Aktivitäten im %{site_link} seit dem %{date}"
-      subject_template: "[%{email_prefix}] Update vom %{date}"
-      unsubscribe: "Zum deaktivieren dieser täglichen Übersicht %{unsubscribe_link} oder ändere %{email_preferences_link}."
+      subject_template_daily: "[%{email_prefix}] Taegliches Aktivitaets-Update fuer %{date}"
+      subject_template_weekly: "[%{email_prefix}] Woechentliches Aktivitaets-Update fuer %{date}"
+      unsubscribe: "Diese E-Mail mit Aktivitaets-Update wird taeglich gesendet, weil Aktivitaets-Updates in deinen Einstellungen aktiviert sind. Zum Abbestellen %{unsubscribe_link} oder aendere %{email_preferences_link}."
       your_email_settings: "Deine Email-Einstellungen"
       click_here: "klicke hier"
-      from: "%{site_name} Zusammenfassung"
+      from: "%{site_name} Aktivitaets-Update"
       new_topics: "Neue Themen"
       topic_updates: "Neuigkeiten in bestehenden Themen"
       view_this_topic: "Dieses Thema im Forum anschauen"
@@ -27,7 +30,7 @@ de:
       back_to_top: "Zurück zum Anfang"
 
   unsubscribe:
-    unsubscribe_daily_summaries: "Tägliche Zuammenstellung neuer Beiträge abbestellen"
+    unsubscribe_daily_summaries: "E-Mails mit Aktivitaets-Updates abbestellen"
     daily_summary:
-      enabled_groups: "Die Mitgliedschaft in diesen Gruppen abboniert automatisch die tägliche Zusammenfassung:"
-      leave_groups: "Bitte verlasse diese Gruppen, um die tägliche Zusammenfassung abzustellen."
+      enabled_groups: "Die Mitgliedschaft in diesen Gruppen abonniert dich automatisch fuer E-Mails mit Aktivitaets-Updates:"
+      leave_groups: "Bitte verlasse diese Gruppen, um E-Mails mit Aktivitaets-Updates zu deaktivieren."

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -13,6 +13,7 @@ de:
     mail_daily_summary_day_of_week: 'Wochentag, an dem die E-Mail mit Aktivitaets-Update gesendet wird (0 = Sonntag)'
     mail_daily_summary_max_posts_per_topic: 'Maximale Anzahl der pro Thema angezeigten Beitraege in periodischen E-Mails mit Aktivitaets-Updates (0 = kein Maximum)'
     mail_daily_summary_min_excerpt_length: 'Auszugslaenge fuer den Abschneidepunkt je angezeigtem Beitrag in periodischen E-Mails mit Aktivitaets-Updates (0 = kein Maximum)'
+    mail_daily_summary_max_excerpt_length: 'Maximale Auszugslaenge je angezeigtem Beitrag in periodischen E-Mails mit Aktivitaets-Updates, wenn Text-basierte Ersetzung verwendet wird (0 = kein Maximum)'
     mail_daily_summary_preview_uses_daily_summary: 'In der Admin-Vorschau periodisches Aktivitaets-Update statt Digest verwenden'
   user_notifications:
     daily_summary:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,24 +1,25 @@
 en:
   site_settings:
-    mail_daily_summary_enabled: 'Allow users to receive a daily summary.'
+    mail_daily_summary_enabled: 'Allow users to receive a periodical activity update email.'
     mail_daily_summary_enable_as_default: 'Enable for all users without custom setting.'
-    mail_daily_summary_at: 'What time should the summary be generated? (HH:MM)'
+    mail_daily_summary_at: 'What time should the activity update email be generated? (HH:MM)'
     mail_daily_summary_last_run_at: 'Timestamp of last run'
     mail_daily_summary_debug_mode: 'Enable Debug Mode'
     mail_daily_summary_add_unsubscribe_link: 'Add an unsubscribe link'
-    mail_daily_summary_enabled_categories: 'If set, only topics inside these categories (including subcategories) will be included into the summary'
-    mail_daily_summary_auto_enabled_groups: 'This groups will get summaries, independent of individual settings'
-    mail_daily_summary_frequency: "Frequency of summary emails"
-    mail_daily_summary_day_of_week: "Day of the week to send the summary (0 = Sunday)"
-    mail_daily_summary_max_posts_per_topic: "Maximum number of posts shown per topic in daily summary emails (0 = no maximum)"
-    mail_daily_summary_min_excerpt_length: "Excerpt cutoff length for each shown post in daily summary emails (0 = no maximum)"
-    mail_daily_summary_preview_uses_daily_summary: "Use daily summary instead of digest in the admin preview digest endpoint"
+    mail_daily_summary_enabled_categories: 'If set, only topics inside these categories (including subcategories) will be included into the activity update email'
+    mail_daily_summary_auto_enabled_groups: 'This groups will get activity update emails, independent of individual settings'
+    mail_daily_summary_frequency: "Default frequency of activity update emails"
+    mail_daily_summary_day_of_week: "Day of the week to send the activity update email (0 = Sunday)"
+    mail_daily_summary_max_posts_per_topic: "Maximum number of posts shown per topic in periodical activity update emails (0 = no maximum)"
+    mail_daily_summary_min_excerpt_length: "Excerpt cutoff length for each shown post in periodical activity update emails (0 = no maximum)"
+    mail_daily_summary_preview_uses_daily_summary: "Use periodical activity update instead of digest in the admin preview digest endpoint"
   user_notifications:
     daily_summary:
       why: "Activity on %{site_link} since %{date}"
-      subject_template: "[%{email_prefix}] Daily update for %{date}"
-      unsubscribe: "This summary is sent daily due to mail daily summary being enabled in your preferences. To unsubscribe %{unsubscribe_link} or change %{email_preferences_link}."
-      from: "%{site_name} summary"
+      subject_template_daily: "[%{email_prefix}] Daily Activity Update for %{date}"
+      subject_template_weekly: "[%{email_prefix}] Weekly Activity Update for %{date}"
+      unsubscribe: "This activity update email is sent daily due to Activity Update email being enabled in your preferences. To unsubscribe %{unsubscribe_link} or change %{email_preferences_link}."
+      from: "%{site_name} Activity Update"
       new_topics: "New topics"
       topic_updates: "Topic updates"
       view_this_topic: "View this topic"
@@ -28,7 +29,7 @@ en:
       click_here: "click here"
 
   unsubscribe:
-    unsubscribe_daily_summaries: "Unsubscribe from daily summaries"
+    unsubscribe_daily_summaries: "Unsubscribe from activity update emails"
     daily_summary:
-      enabled_groups: "Membership in these groups automatically subscribes you to the daily summary:"
-      leave_groups: "Please leave these groups to turn off the daily summary."
+      enabled_groups: "Membership in these groups automatically subscribes you to activity update emails:"
+      leave_groups: "Please leave these groups to turn off the activity update emails."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -12,6 +12,7 @@ en:
     mail_daily_summary_day_of_week: "Day of the week to send the activity update email (0 = Sunday)"
     mail_daily_summary_max_posts_per_topic: "Maximum number of posts shown per topic in periodical activity update emails (0 = no maximum)"
     mail_daily_summary_min_excerpt_length: "Excerpt cutoff length for each shown post in periodical activity update emails (0 = no maximum)"
+    mail_daily_summary_max_excerpt_length: "Maximum excerpt length for each shown post in periodical activity update emails when fallback text truncation is used (0 = no maximum)"
     mail_daily_summary_preview_uses_daily_summary: "Use periodical activity update instead of digest in the admin preview digest endpoint"
   user_notifications:
     daily_summary:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -48,5 +48,9 @@ plugins:
     default: 0
     type: integer
     min: 0
+  mail_daily_summary_max_excerpt_length:
+    default: 0
+    type: integer
+    min: 0
   mail_daily_summary_preview_uses_daily_summary:
     default: false

--- a/lib/discourse_mail_daily_summary/admin_email_controller_extension.rb
+++ b/lib/discourse_mail_daily_summary/admin_email_controller_extension.rb
@@ -20,5 +20,36 @@ module MailDailySummary
         render json: { errors: ["No content available for preview"] }, status: :unprocessable_entity
       end
     end
+
+    def send_digest
+      return super unless SiteSetting.mail_daily_summary_preview_uses_daily_summary
+
+      params.require(:last_seen_at)
+      params.require(:username)
+      params.require(:email)
+      user = User.find_by_username(params[:username])
+      raise Discourse::InvalidParameters unless user
+
+      message, skip_reason =
+        UserNotifications.public_send(
+          :daily_summary,
+          user,
+          since: params[:last_seen_at],
+          skip_unsubscribe_links: true,
+        )
+
+      if message
+        message.to = params[:email]
+
+        begin
+          Email::Sender.new(message, :daily_summary).send
+          render json: success_json
+        rescue => e
+          render json: { errors: [e.message] }, status: :unprocessable_entity
+        end
+      else
+        render json: { errors: skip_reason }
+      end
+    end
   end
 end

--- a/lib/discourse_mail_daily_summary/user_notifications_extension.rb
+++ b/lib/discourse_mail_daily_summary/user_notifications_extension.rb
@@ -48,11 +48,15 @@ module MailDailySummary
       @unsubscribe_key = UnsubscribeKey.create_key_for(user, MailDailySummary::UNSUBSCRIBE)
 
       build_summary_for(user)
+
+      # Determine frequency for subject line
+      frequency = opts[:frequency] || "daily"
+
       opts = {
         from_alias: I18n.t("user_notifications.daily_summary.from", site_name: SiteSetting.title),
         subject:
           I18n.t(
-            "user_notifications.daily_summary.subject_template",
+            "user_notifications.daily_summary.subject_template_#{frequency}",
             email_prefix: @email_prefix,
             date: @date,
           ),

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-mail-daily-summary
 # about: Send a daily summary email.
-# version: 0.15.2
+# version: 0.15.3
 # authors: Thomas Kalka and Communiteq
 # url: https://www.github.com/thoka/discourse-mail-daily-summary
 # meta_topic_id: 306214

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-mail-daily-summary
 # about: Send a daily summary email.
-# version: 0.15
+# version: 0.15.1
 # authors: Thomas Kalka and Communiteq
 # url: https://www.github.com/thoka/discourse-mail-daily-summary
 # meta_topic_id: 306214

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-mail-daily-summary
 # about: Send a daily summary email.
-# version: 0.15.1
+# version: 0.15.2
 # authors: Thomas Kalka and Communiteq
 # url: https://www.github.com/thoka/discourse-mail-daily-summary
 # meta_topic_id: 306214

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # name: discourse-mail-daily-summary
 # about: Send a daily summary email.
-# version: 0.14
-# authors: Thomas Kalka
+# version: 0.15
+# authors: Thomas Kalka and Communiteq
 # url: https://www.github.com/thoka/discourse-mail-daily-summary
 # meta_topic_id: 306214
 
@@ -11,6 +11,7 @@
 enabled_site_setting :mail_daily_summary_enabled
 
 DiscoursePluginRegistry.serialized_current_user_fields << "user_mlm_daily_summary_enabled"
+DiscoursePluginRegistry.serialized_current_user_fields << "user_mail_summary_frequency"
 
 require_relative "lib/discourse_mail_daily_summary/engine"
 
@@ -25,6 +26,13 @@ after_initialize do
   # TODO change name? this name is historical
   User.register_custom_field_type("user_mlm_daily_summary_enabled", :boolean)
   register_editable_user_custom_field :user_mlm_daily_summary_enabled
+
+  # New frequency override field
+  User.register_custom_field_type("user_mail_summary_frequency", :string)
+  register_editable_user_custom_field :user_mail_summary_frequency
+
+  # Per-user send tracking
+  User.register_custom_field_type("user_mail_summary_last_sent_at", :datetime)
 
   reloadable_patch do |plugin|
     UserNotifications.prepend MailDailySummary::UserNotificationsExtension

--- a/spec/helpers/mail_daily_summary_helper_spec.rb
+++ b/spec/helpers/mail_daily_summary_helper_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../app/helpers/mail_daily_summary_helper"
+
+describe MailDailySummaryHelper do
+  let(:helper_instance) { Class.new { include MailDailySummaryHelper }.new }
+
+  describe "#daily_summary_excerpt_data" do
+    fab!(:list_post) do
+      Fabricate(
+        :post,
+        raw: <<~RAW,
+          * This is a very long first list item with many words to make the excerpt exceed the configured limit
+          * This is a very long second list item with many words to keep the total excerpt text length high
+          * This is a very long third list item to ensure the fallback algorithm is exercised
+        RAW
+      )
+    end
+
+    fab!(:word_boundary_post) { Fabricate(:post, raw: "one two three four five six seven") }
+
+    before do
+      without_partial_double_verification do
+        allow(SiteSetting).to receive(:mail_daily_summary_min_excerpt_length).and_return(20)
+      end
+    end
+
+    it "falls back to plain text with ellipsis when paragraph extraction exceeds max" do
+      maximum_length = 40
+
+      without_partial_double_verification do
+        allow(SiteSetting).to receive(:mail_daily_summary_max_excerpt_length).and_return(maximum_length)
+      end
+
+      data = helper_instance.send(:daily_summary_excerpt_data, list_post)
+
+      expect(data[:truncated]).to eq(true)
+      expect(data[:html]).to end_with("...")
+      expect(data[:html]).not_to include("<ul")
+      expect(data[:html].length).to be < maximum_length
+    end
+
+    it "truncates on a word boundary in fallback mode" do
+      without_partial_double_verification do
+        allow(SiteSetting).to receive(:mail_daily_summary_max_excerpt_length).and_return(15)
+      end
+
+      data = helper_instance.send(:daily_summary_excerpt_data, word_boundary_post)
+
+      expect(data[:html]).to eq("one two...")
+      expect(data[:html]).to end_with("...")
+      expect(data[:html].length).to be < 15
+    end
+
+    it "uses plain-text fallback when min is 0 and max is set" do
+      without_partial_double_verification do
+        allow(SiteSetting).to receive(:mail_daily_summary_min_excerpt_length).and_return(0)
+        allow(SiteSetting).to receive(:mail_daily_summary_max_excerpt_length).and_return(40)
+      end
+
+      data = helper_instance.send(:daily_summary_excerpt_data, list_post)
+
+      expect(data[:truncated]).to eq(true)
+      expect(data[:html]).to end_with("...")
+      expect(data[:html]).not_to include("<ul")
+      expect(data[:html].length).to be < 40
+    end
+  end
+end

--- a/spec/helpers/mail_daily_summary_helper_spec.rb
+++ b/spec/helpers/mail_daily_summary_helper_spec.rb
@@ -36,7 +36,7 @@ describe MailDailySummaryHelper do
       data = helper_instance.send(:daily_summary_excerpt_data, list_post)
 
       expect(data[:truncated]).to eq(true)
-      expect(data[:html]).to end_with("...")
+      expect(data[:html]).to end_with("…")
       expect(data[:html]).not_to include("<ul")
       expect(data[:html].length).to be < maximum_length
     end
@@ -48,8 +48,8 @@ describe MailDailySummaryHelper do
 
       data = helper_instance.send(:daily_summary_excerpt_data, word_boundary_post)
 
-      expect(data[:html]).to eq("one two...")
-      expect(data[:html]).to end_with("...")
+      expect(data[:html]).to eq("one two…")
+      expect(data[:html]).to end_with("…")
       expect(data[:html].length).to be < 15
     end
 
@@ -62,7 +62,7 @@ describe MailDailySummaryHelper do
       data = helper_instance.send(:daily_summary_excerpt_data, list_post)
 
       expect(data[:truncated]).to eq(true)
-      expect(data[:html]).to end_with("...")
+      expect(data[:html]).to end_with("…")
       expect(data[:html]).not_to include("<ul")
       expect(data[:html].length).to be < 40
     end

--- a/spec/jobs/enqueue_mail_daily_summary_spec.rb
+++ b/spec/jobs/enqueue_mail_daily_summary_spec.rb
@@ -12,6 +12,10 @@ describe Jobs::EnqueueMailDailySummary do
 
   before do
     without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_enabled).and_return(true)
+      allow(SiteSetting).to receive(:mail_daily_summary_at).and_return("")
+      allow(SiteSetting).to receive(:mail_daily_summary_day_of_week).and_return(0)
+      allow(SiteSetting).to receive(:mail_daily_summary_debug_mode).and_return(false)
       allow(SiteSetting).to receive(:mail_daily_summary_enable_as_default).and_return(true)
       allow(SiteSetting).to receive(:mail_daily_summary_frequency).and_return("daily")
       allow(SiteSetting).to receive(:must_approve_users?).and_return(false)
@@ -89,5 +93,61 @@ describe Jobs::EnqueueMailDailySummary do
 
     weekly_ids = job.target_weekly_users
     expect(weekly_ids).not_to include(default_user.id)
+  end
+
+  it "does not enqueue before configured send time" do
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_at).and_return("14:00")
+    end
+
+    allow(Time.zone).to receive(:now).and_return(Time.zone.parse("2026-04-22 13:30:00"))
+
+    expect(job).not_to receive(:target_daily_users)
+    expect(job).not_to receive(:target_weekly_users)
+    expect(Jobs).not_to receive(:enqueue)
+
+    job.execute({})
+  end
+
+  it "enqueues daily only after configured time when weekday does not match weekly day" do
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_at).and_return("14:00")
+      allow(SiteSetting).to receive(:mail_daily_summary_day_of_week).and_return(0)
+    end
+
+    allow(Time.zone).to receive(:now).and_return(Time.zone.parse("2026-04-22 14:30:00")) # Wednesday
+    allow(job).to receive(:target_daily_users).and_return([default_user.id])
+    expect(job).not_to receive(:target_weekly_users)
+    allow(Jobs).to receive(:enqueue)
+
+    job.execute({})
+
+    expect(Jobs).to have_received(:enqueue).with(
+      :user_daily_summary_email,
+      { type: "daily_summary", user_id: default_user.id, frequency: "daily" },
+    ).once
+  end
+
+  it "enqueues daily and weekly after configured time when weekday matches" do
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_at).and_return("14:00")
+      allow(SiteSetting).to receive(:mail_daily_summary_day_of_week).and_return(3)
+    end
+
+    allow(Time.zone).to receive(:now).and_return(Time.zone.parse("2026-04-22 14:30:00")) # Wednesday
+    allow(job).to receive(:target_daily_users).and_return([default_user.id])
+    allow(job).to receive(:target_weekly_users).and_return([explicit_weekly_user.id])
+    allow(Jobs).to receive(:enqueue)
+
+    job.execute({})
+
+    expect(Jobs).to have_received(:enqueue).with(
+      :user_daily_summary_email,
+      { type: "daily_summary", user_id: default_user.id, frequency: "daily" },
+    ).once
+    expect(Jobs).to have_received(:enqueue).with(
+      :user_daily_summary_email,
+      { type: "daily_summary", user_id: explicit_weekly_user.id, frequency: "weekly" },
+    ).once
   end
 end

--- a/spec/jobs/enqueue_mail_daily_summary_spec.rb
+++ b/spec/jobs/enqueue_mail_daily_summary_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../app/jobs/scheduled/enqueue_mail_daily_summary"
+
+describe Jobs::EnqueueMailDailySummary do
+  fab!(:default_user) { Fabricate(:user) }
+  fab!(:explicit_daily_user) { Fabricate(:user) }
+  fab!(:explicit_weekly_user) { Fabricate(:user) }
+
+  let(:job) { described_class.new }
+
+  before do
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_enable_as_default).and_return(true)
+      allow(SiteSetting).to receive(:mail_daily_summary_frequency).and_return("daily")
+      allow(SiteSetting).to receive(:must_approve_users?).and_return(false)
+    end
+  end
+
+  def set_frequency(user, value)
+    user.custom_fields["user_mail_summary_frequency"] = value
+    user.save_custom_fields(true)
+  end
+
+  def set_last_sent_at(user, time)
+    user.custom_fields["user_mail_summary_last_sent_at"] = time.to_s
+    user.save_custom_fields(true)
+  end
+
+  it "daily target includes default users when site default is daily" do
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_frequency).and_return("daily")
+    end
+
+    set_frequency(explicit_daily_user, "daily")
+    set_frequency(explicit_weekly_user, "weekly")
+
+    ids = job.target_daily_users
+
+    expect(ids).to include(default_user.id)
+    expect(ids).to include(explicit_daily_user.id)
+    expect(ids).not_to include(explicit_weekly_user.id)
+  end
+
+  it "daily target includes only explicit daily overrides when site default is weekly" do
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_frequency).and_return("weekly")
+    end
+
+    set_frequency(explicit_daily_user, "daily")
+    set_frequency(explicit_weekly_user, "weekly")
+
+    ids = job.target_daily_users
+
+    expect(ids).to include(explicit_daily_user.id)
+    expect(ids).not_to include(default_user.id)
+    expect(ids).not_to include(explicit_weekly_user.id)
+  end
+
+  it "weekly target includes default users when site default is weekly" do
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_frequency).and_return("weekly")
+    end
+
+    set_frequency(explicit_daily_user, "daily")
+    set_frequency(explicit_weekly_user, "weekly")
+
+    ids = job.target_weekly_users
+
+    expect(ids).to include(default_user.id)
+    expect(ids).to include(explicit_weekly_user.id)
+    expect(ids).not_to include(explicit_daily_user.id)
+  end
+
+  it "respects last_sent_at threshold for daily and weekly" do
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_frequency).and_return("daily")
+    end
+    set_last_sent_at(default_user, 2.hours.ago)
+
+    daily_ids = job.target_daily_users
+    expect(daily_ids).not_to include(default_user.id)
+
+    without_partial_double_verification do
+      allow(SiteSetting).to receive(:mail_daily_summary_frequency).and_return("weekly")
+    end
+    set_last_sent_at(default_user, 2.days.ago)
+
+    weekly_ids = job.target_weekly_users
+    expect(weekly_ids).not_to include(default_user.id)
+  end
+end


### PR DESCRIPTION
- Allow users to override the daily/weekly frequency on an individual basis
- Change user-facing terminology to "Activity Update" to avoid confusion with the "Summary" / "Digest" that is in core
- Add plugin icon
- Make preview *sending* use the daily summary as well if `mail_daily_summary_preview_uses_daily_summary` is enabled